### PR TITLE
Projects api for an organization's team

### DIFF
--- a/src/main/java/com/amihaiemil/versioneye/MkVersionEye.java
+++ b/src/main/java/com/amihaiemil/versioneye/MkVersionEye.java
@@ -118,5 +118,9 @@ public final class MkVersionEye implements VersionEye {
         );
         this.server.storage().add("authenticated", users.build());
     }
+    @Override
+    public Organizations organizations() {
+        return null;
+    }
 
 }

--- a/src/main/java/com/amihaiemil/versioneye/Organization.java
+++ b/src/main/java/com/amihaiemil/versioneye/Organization.java
@@ -44,12 +44,6 @@ public interface Organization {
     Teams teams();
     
     /**
-     * The organization's projects.
-     * @return Projects.
-     */
-    Projects projects();
-
-    /**
      * Organization name.
      * @return String organization name.
      */

--- a/src/main/java/com/amihaiemil/versioneye/Organizations.java
+++ b/src/main/java/com/amihaiemil/versioneye/Organizations.java
@@ -55,4 +55,5 @@ public interface Organizations {
      *  making the HTTP call.
      */
     Organization organization(String organizationName) throws IOException;
+    
 }

--- a/src/main/java/com/amihaiemil/versioneye/Project.java
+++ b/src/main/java/com/amihaiemil/versioneye/Project.java
@@ -1,0 +1,17 @@
+package com.amihaiemil.versioneye;
+
+/**
+ * A project on VersionEye.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 1.0.0
+ * @todo #38:30min/DEV Provide and unit test RtProject.
+ */
+public interface Project {
+    
+    /**
+     * The team which holds this project.
+     * @return Team.
+     */
+    Team team();
+}

--- a/src/main/java/com/amihaiemil/versioneye/Projects.java
+++ b/src/main/java/com/amihaiemil/versioneye/Projects.java
@@ -27,15 +27,27 @@
  */
 package com.amihaiemil.versioneye;
 
+import java.io.IOException;
+import java.util.List;
+
 /**
- * An organization's projects.
+ * A team's projects.
  * @author Sherif Waly (sherifwaly95@gmail.com)
  * @version $Id$
  * @since 1.0.0
- * @todo #27:30min/DEV Provide RtProjects implementation and unit tests.
- *  The class should work with a given request and organization name.
- * 
  */
 public interface Projects {
-
+    
+    /**
+     * Fetch the projects.
+     * @return List of Project.
+     * @throws IOException If something goes wrong with the HTTP call.
+     */
+    List<Project> fetch() throws IOException;
+    
+    /**
+     * The team responsible for these projects.
+     * @return Team
+     */
+    Team team();
 }

--- a/src/main/java/com/amihaiemil/versioneye/RtOrganization.java
+++ b/src/main/java/com/amihaiemil/versioneye/RtOrganization.java
@@ -51,23 +51,28 @@ final class RtOrganization implements Organization {
     private Request req;
     
     /**
+     * API entry point.
+     */
+    private Request entry;
+    
+    /**
      * Ctor.
      * @param organization Json organization as returned by API. 
-     * @param entry HTTP request.
+     * @param req HTTP request for Organization.
+     * @param entry Initial HTTP request, entry point of the API.
      */
-    RtOrganization(final JsonObject organization, final Request entry) {
+    RtOrganization(
+        final JsonObject organization, final Request req,
+        final Request entry
+    ) {
         this.organization = organization;
-        this.req = entry.uri().path(organization.getString("name")).back();
+        this.req = req.uri().path(organization.getString("name")).back();
+        this.entry = entry;
     }
 
     @Override
     public Teams teams() {
-        return new RtTeams(this.req, this.organization.getString("api_key"));
-    }
-
-    @Override
-    public Projects projects() {
-        return null;
+        return new RtTeams(this.entry, this.req, this);
     }
 
     @Override
@@ -99,4 +104,5 @@ final class RtOrganization implements Organization {
     public JsonObject json() {
         return this.organization;
     }
+
 }

--- a/src/main/java/com/amihaiemil/versioneye/RtOrganizations.java
+++ b/src/main/java/com/amihaiemil/versioneye/RtOrganizations.java
@@ -47,15 +47,21 @@ import com.jcabi.http.response.RestResponse;
 final class RtOrganizations implements Organizations {
 
     /**
-     * HTTP request.
+     * HTTP request for organizations.
      */
     private Request req;
+    
+    /**
+     * Initial HTTP request, the API's entry point.
+     */
+    private Request entry;
 
     /**
      * Ctor.
      * @param entry HTTP Request.
      */
     RtOrganizations(final Request entry) {
+        this.entry = entry;
         this.req = entry.uri().path("/organisations").back();
     }
     
@@ -86,16 +92,18 @@ final class RtOrganizations implements Organizations {
      *  making the HTTP call.
      */
     private List<Organization> fetchOrgs() throws IOException {
-        final JsonArray array = this.req.fetch()
+        final JsonArray orgs = this.req.fetch()
             .as(RestResponse.class)
             .assertStatus(HttpURLConnection.HTTP_OK)
             .as(JsonResponse.class)
             .json()
             .readArray();
         final List<Organization> organizations = new ArrayList<>();
-        for(int idx=0; idx<array.size(); idx++) {
+        for(int idx=0; idx<orgs.size(); idx++) {
             organizations.add(
-                new RtOrganization(array.getJsonObject(idx), this.req)
+                new RtOrganization(
+                    orgs.getJsonObject(idx), this.req, this.entry
+                )
             );
         }
         return organizations;

--- a/src/main/java/com/amihaiemil/versioneye/RtProjects.java
+++ b/src/main/java/com/amihaiemil/versioneye/RtProjects.java
@@ -28,79 +28,53 @@
 package com.amihaiemil.versioneye;
 
 import java.io.IOException;
+import java.util.List;
 
 import com.jcabi.http.Request;
-import com.jcabi.http.request.JdkRequest;
-import com.jcabi.http.wire.TrustedWire;
 
 /**
- * OOP wrapper for the VersionEye API.
+ * Real implementation of {@link Projects}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
+ * @todo #38:30min/DEV Implement and unit test method fetch().
+ *
  */
-public final class RtVersionEye implements VersionEye {
+final class RtProjects implements Projects {
 
     /**
-     * Default HTTP request.
+     * HTTP request for /projects.
      */
-    private static final Request DEFAULT = new JdkRequest(
-        "https://www.versioneye.com/api/v2"
-    ).header("Accept", "application/json");
+    private Request req;
     
     /**
-     * HTTP request.
+     * The team responsible for these projects.
      */
-    private Request entry;
-
+    private Team team;
+    
     /**
      * Ctor.
+     * @param req Request for /projects.
+     * @param team Team responsible for these projects;
      */
-    public RtVersionEye() {
-        this(RtVersionEye.DEFAULT);
-    }
-
-    /**
-     * Ctor.
-     * @param token Api token.
-     */
-    public RtVersionEye(final String token) {
-        this(RtVersionEye.DEFAULT.header("Cookie", "api_key=" + token));
-    }
-
-    /**
-     * Ctor.
-     * @param req HTTP Request. (see {@link Request})
-     */
-    public RtVersionEye(final Request req) {
-        this.entry = req;
+    RtProjects(final Request req, final Team team) {
+        this.req = req.uri()
+            .path("/projects")
+            .queryParam("orga_name", team.organization().name())
+            .queryParam("team_name", team.name())
+            .queryParam("api_key", team.organization().apiKey())
+            .back();
+        this.team = team;
     }
     
     @Override
-    public Services services() {
-        return new RtServices(this.entry);
+    public List<Project> fetch() throws IOException {
+        return null;
     }
 
     @Override
-    public Users users() {
-        return new RtUsers(this.entry);
-    }
-    
-    @Override
-    public VersionEye trusted() throws IOException {
-        return new RtVersionEye(
-            this.entry.through(TrustedWire.class)
-        );
+    public Team team() {
+        return this.team;
     }
 
-    @Override
-    public Me me() {
-        return new RtMe(this.entry);
-    }
-
-    @Override
-    public Organizations organizations() {
-        return new RtOrganizations(this.entry);
-    }
-   
 }

--- a/src/main/java/com/amihaiemil/versioneye/RtTeam.java
+++ b/src/main/java/com/amihaiemil/versioneye/RtTeam.java
@@ -29,9 +29,9 @@ package com.amihaiemil.versioneye;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.json.JsonArray;
 import javax.json.JsonObject;
+import com.jcabi.http.Request;
 
 /**
  * VersionEye Team backed by a JsonObject.
@@ -39,19 +39,36 @@ import javax.json.JsonObject;
  * @version $Id$
  * @since 1.0.0
  */
-final class JsonTeam implements Team {
+final class RtTeam implements Team {
 
     /**
-     * Team.
+     * This team as Json.
      */
     private JsonObject team;
     
     /**
+     * This team's organization.
+     */
+    private Organization orga;
+    
+    /**
+     * Initial HTTP request, entry point of the API.
+     */
+    private Request entry;
+
+    /**
      * Ctor.
      * @param team Given team.
+     * @param orga This team's organization.
+     * @param entry HTTP Request.
      */
-    JsonTeam(final JsonObject team) {
+    RtTeam(
+        final JsonObject team, final Organization orga,
+        final Request entry
+    ) {
         this.team = team;
+        this.entry = entry;
+        this.orga = orga;
     }
     
     @Override
@@ -137,6 +154,16 @@ final class JsonTeam implements Team {
     @Override
     public JsonObject json() {
         return this.team;
+    }
+
+    @Override
+    public Projects projects() {
+        return new RtProjects(this.entry, this);
+    }
+
+    @Override
+    public Organization organization() {
+        return this.orga;
     }
 
 }

--- a/src/main/java/com/amihaiemil/versioneye/RtTeams.java
+++ b/src/main/java/com/amihaiemil/versioneye/RtTeams.java
@@ -45,17 +45,30 @@ import com.jcabi.http.response.RestResponse;
 final class RtTeams implements Teams {
 
     /**
-     * HTTP request.
+     * Initial HTTP request, entry point of the API.
+     */
+    private Request entry;
+    
+    /**
+     * HTTP request for Teams endpoint.
      */
     private Request req;
     
     /**
-     * Ctor.
-     * @param entry HTTP request.
-     * @param orgKey The organization's api_key
+     * These teams' organization.
      */
-    RtTeams(final Request entry, final String orgKey) {
-        this.req = entry.uri().queryParam("api_key", orgKey).back();
+    private Organization orga;
+    
+    /**
+     * Ctor.
+     * @param req HTTP request for Teams.
+     * @param entry Original API entry point.
+     * @param orga The parent organization.
+     */
+    RtTeams(final Request entry, final Request req, final Organization orga) {
+        this.entry = entry;
+        this.req = req.uri().path("/teams")
+            .queryParam("api_key", orga.apiKey()).back();
     }
     
     @Override
@@ -69,10 +82,15 @@ final class RtTeams implements Teams {
         final List<Team> teams = new ArrayList<>();
         for(int idx=0; idx<array.size(); idx++) {
             teams.add(
-                new JsonTeam(array.getJsonObject(idx))
+                new RtTeam(array.getJsonObject(idx), this.orga, this.entry)
             );
         }
         return teams;
+    }
+
+    @Override
+    public Organization organization() {
+        return this.orga;
     }
 
 }

--- a/src/main/java/com/amihaiemil/versioneye/Team.java
+++ b/src/main/java/com/amihaiemil/versioneye/Team.java
@@ -113,6 +113,18 @@ public interface Team {
     boolean sunday();
     
     /**
+     * This team's projects.
+     * @return Projects.
+     */
+    Projects projects();
+    
+    /**
+     * This team's organization.
+     * @return Organization.
+     */
+    Organization organization();
+    
+    /**
      * Members of this team.
      * @return List of UserData.
      */

--- a/src/main/java/com/amihaiemil/versioneye/Teams.java
+++ b/src/main/java/com/amihaiemil/versioneye/Teams.java
@@ -44,4 +44,10 @@ public interface Teams {
      * @throws IOException If something goes wrong with the HTTP request.
      */
     List<Team> fetch() throws IOException;
+    
+    /**
+     * The teams' organization.
+     * @return Organization.
+     */
+    Organization organization();
 }

--- a/src/main/java/com/amihaiemil/versioneye/VersionEye.java
+++ b/src/main/java/com/amihaiemil/versioneye/VersionEye.java
@@ -51,6 +51,12 @@ public interface VersionEye {
     Users users();
     
     /**
+     * Organizations api.
+     * @return Organizations.
+     */
+    Organizations organizations();
+    
+    /**
      * Me api.
      * @return Me.
      * @checkstyle MethodName (3 lines).

--- a/src/test/java/com/amihaiemil/versioneye/RtOrganizationsTestCase.java
+++ b/src/test/java/com/amihaiemil/versioneye/RtOrganizationsTestCase.java
@@ -146,7 +146,8 @@ public final class RtOrganizationsTestCase {
         MatcherAssert.assertThat(
             container.take().uri().toString(),
             Matchers.equalTo(
-                "/organisations/sherifwaly_orga?api_key=88870f2710dba853a326"
+                "/organisations/sherifwaly_orga/"
+                + "teams?api_key=88870f2710dba853a326"
             )
         );
         MatcherAssert.assertThat(teams.size(), Matchers.is(2));


### PR DESCRIPTION
PR for #38 

@SherifWaly 
This is rather big PR (I got carried away, haha).
Some changes:
* projects will be accessed through a Team, since any project belongs to a Team.
* there is also an endpoint to get all the projects from the organization, but I left that out (I removed ``Organization.projects()``) since it's more complicated to integrate with the Team's one, and the team makes more sense. If a user will want all the projects, he'll simply iterate over the teams first.
* passed around the Organization and/or Team for convenience. For instance, a Team has a method to return its Organization, a Project must know its Organization and Team (they are part of the Json etc.
* If you look, from Organization deeper (e.g. teams, team etc), I started passing around also the original request. This is because the projects path comes right after the domain, with some query strings (e.g. ``/projects?a&b&c``, instead of comming after ``/organization/{team_name}`` for example -- and if I don't do it like this, by the time the request from ``Organizations`` reaches ``Projects``, it already has the path built, which cannot be changed.